### PR TITLE
Add basic Vulkan loader library presence checking for supported platforms

### DIFF
--- a/src/Application/Application.cpp
+++ b/src/Application/Application.cpp
@@ -97,12 +97,22 @@ void checkVulkanLoader() {
 
     switch (vkLoaderDiag.errType) {
     case SystemUtils::VkLoaderDiag::CANNOT_BE_LOCATED:
+#if _WIN32
         vkLoaderErrMsg = vkLoader + " could not be located! This file is distributed as part of your GPU driver. Please reinstall your GPU drivers from your manufacturer and ensure that " + vkLoader + " is available in C:/Windows/System32 or in the application's bin/ directory.";
+#elif defined(__linux__)
+        vkLoaderErrMsg = vkLoader + " could not be located! Please reinstall your GPU driver package and ensure that " + vkLoader + " is available in your runtime linker search path (e.g., /usr/lib, /usr/lib64).";
+#elif defined(__APPLE__)
+        vkLoaderErrMsg = vkLoader + " could not be located! Please reinstall your Vulkan runtime/MoltenVK package and ensure that " + vkLoader + " is available in your dynamic library search path.";
+#endif
         break;
 
     case SystemUtils::VkLoaderDiag::CANNOT_BE_LOADED:
-    default:
         vkLoaderErrMsg = vkLoader + " appears to be damaged or incompatible. Please perform a clean reinstallation of your GPU drivers from your manufacturer.";
+        break;
+
+    case SystemUtils::VkLoaderDiag::UNSUPPORTED:
+    default:
+        vkLoaderErrMsg = "Failed to locate " + vkLoader + ": failed to identify operating system!";
         break;
     }
 
@@ -124,6 +134,9 @@ int main(int argc, char *argv[]) {
 
         checkVulkanLoader();
 
+        engine.init();
+        std::this_thread::sleep_for(std::chrono::seconds(3)); // Sleep for enough time for the user to see the splash screen
+        engine.loadMainWindow();
         engine.run();
     }
 

--- a/src/Application/Application.cpp
+++ b/src/Application/Application.cpp
@@ -90,18 +90,40 @@ void tryOpenConsole() {
 }
 
 
+void checkVulkanLoader() {
+    SystemUtils::VkLoaderDiag vkLoaderDiag = SystemUtils::VulkanLoaderExists();
+    std::string vkLoader = VULKAN_LOADER;
+    std::string vkLoaderErrMsg;
+
+    switch (vkLoaderDiag.errType) {
+    case SystemUtils::VkLoaderDiag::CANNOT_BE_LOCATED:
+        vkLoaderErrMsg = vkLoader + " could not be located! This file is distributed as part of your GPU driver. Please reinstall your GPU drivers from your manufacturer and ensure that " + vkLoader + " is available in C:/Windows/System32 or in the application's bin/ directory.";
+        break;
+
+    case SystemUtils::VkLoaderDiag::CANNOT_BE_LOADED:
+    default:
+        vkLoaderErrMsg = vkLoader + " appears to be damaged or incompatible. Please perform a clean reinstallation of your GPU drivers from your manufacturer.";
+        break;
+    }
+
+    LOG_ASSERT(vkLoaderDiag.present, vkLoaderErrMsg);
+}
+
+
 int main(int argc, char *argv[]) {
     int processStat = processAppConfig(argc, argv);
     if (processStat != EXIT_SUCCESS) return processStat;
 
     tryOpenConsole();
 
+    Engine engine;
 
     try {
         Log::BeginLogging();
         Log::PrintAppInfo();
 
-        Engine engine;
+        checkVulkanLoader();
+
         engine.run();
     }
 

--- a/src/Application/Engine.cpp
+++ b/src/Application/Engine.cpp
@@ -11,20 +11,6 @@ Engine::Engine() {
 
     m_glfwWindow = std::make_unique<Window>(AppConst::DEFAULT_WINDOW_WIDTH, AppConst::DEFAULT_WINDOW_HEIGHT, APP_NAME);
     m_currentWindow = m_glfwWindow->initSplashScreen();
-
-    init();
-    std::this_thread::sleep_for(std::chrono::seconds(3)); // Sleep for enough time for the user to see the splash screen
-
-    m_oldWindow = m_currentWindow;
-    m_currentWindow = m_glfwWindow->initPrimaryScreen(&g_glfwCallbackCtx);
-    setMainWindow(m_oldWindow, m_currentWindow);
-
-    m_eventDispatcher->dispatch(UpdateEvent::AppIsStable{});
-    m_eventDispatcher->dispatch(UpdateEvent::ApplicationStatus{
-        .appState = Application::State::IDLE
-    });
-
-    Log::Print(Log::T_DEBUG, __FUNCTION__, "Initialized.");
 }
 
 
@@ -52,6 +38,18 @@ void Engine::init() {
 
     // Switch workspace from splash screen to actual GUI
     m_uiPanelManager->switchWorkspace(m_orbitalWorkspace.get());
+}
+
+
+void Engine::loadMainWindow() {
+    m_oldWindow = m_currentWindow;
+    m_currentWindow = m_glfwWindow->initPrimaryScreen(&g_glfwCallbackCtx);
+    setMainWindow(m_oldWindow, m_currentWindow);
+
+    m_eventDispatcher->dispatch(UpdateEvent::AppIsStable{});
+    m_eventDispatcher->dispatch(UpdateEvent::ApplicationStatus{
+        .appState = Application::State::IDLE
+    });
 }
 
 

--- a/src/Application/Engine.hpp
+++ b/src/Application/Engine.hpp
@@ -54,6 +54,8 @@ public:
 
 	void init();
 
+	void loadMainWindow();
+
 	void run();
 
 private:

--- a/src/Core/Data/Constants.h
+++ b/src/Core/Data/Constants.h
@@ -20,7 +20,17 @@ inline std::string DEFAULT_WORKING_DIR = std::filesystem::current_path().string(
 #endif
 
 
-// Vulkan version
+// Vulkan
+#ifdef _WIN32
+	#define VULKAN_LOADER "vulkan-1.dll"
+#elif __linux__
+	#define VULKAN_LOADER "libvulkan.so.1"
+	#define VULKAN_LOADER_LINUX_FALLBACK "libvulkan.so"
+#elif __APPLE__
+	#define VULKAN_LOADER "libvulkan.1.dylib"
+	#define VULKAN_LOADER_APPLE_FALLBACK "libvulkan.dylib"
+#endif
+
 #define VULKAN_VERSION VK_API_VERSION_1_2 // If you decide to change VULKAN_VERSION, also change VMA_VULKAN_VERSION defined in CMakeLists.txt
 #define VULKAN_VERSION_STR "1.2"
 

--- a/src/Core/Utils/SystemUtils.hpp
+++ b/src/Core/Utils/SystemUtils.hpp
@@ -106,11 +106,12 @@ namespace SystemUtils {
     struct VkLoaderDiag {
         enum ErrorType {
             NONE,
+            UNSUPPORTED,
             CANNOT_BE_LOCATED,
             CANNOT_BE_LOADED
         };
 
-        bool present;
+        bool present = false;
         ErrorType errType = NONE;
     };
     /* Checks if the Vulkan loader exists on the current system.
@@ -131,14 +132,14 @@ namespace SystemUtils {
         return { true };
 
 
-#elif defined(__linux__) || defined(__APPLE)
+#elif defined(__linux__) || defined(__APPLE__)
         void *handle = dlopen(VULKAN_LOADER, RTLD_NOW | RTLD_LOCAL);
         if (!handle) {
-#ifdef __linux__
+    #ifdef __linux__
             handle = dlopen(VULKAN_LOADER_LINUX_FALLBACK, RTLD_NOW | RTLD_LOCAL);
-#elif __APPLE__
+    #elif __APPLE__
             handle = dlopen(VULKAN_LOADER_APPLE_FALLBACK, RTLD_NOW | RTLD_LOCAL);
-#endif
+    #endif
             if (!handle)
                 return { false, VkLoaderDiag::CANNOT_BE_LOCATED };
         }
@@ -150,6 +151,9 @@ namespace SystemUtils {
             return { false,VkLoaderDiag::CANNOT_BE_LOADED };
 
         return { true };
+
+#else
+        return { false, VkLoaderDiag::UNSUPPORTED };
 #endif
     }
 }

--- a/src/Core/Utils/SystemUtils.hpp
+++ b/src/Core/Utils/SystemUtils.hpp
@@ -6,12 +6,20 @@
 #include <vector>
 #include <random>
 #include <chrono>
+#include <cstdlib>
 #include <concepts>
 #include <functional>
 
 #include <Platform/External/GLFWVulkan.hpp>
 
 #include <Core/Application/IO/LoggingManager.hpp>
+
+
+#ifdef _WIN32
+#include <windows.h>
+#elif defined(__linux__) || defined(__APPLE__)
+#include <dlfcn.h>
+#endif
 
 
 namespace SystemUtils {
@@ -92,5 +100,56 @@ namespace SystemUtils {
         size_t offset = alignedBufSize * stride;
 
         return static_cast<void*>(base + offset);
+    }
+
+
+    struct VkLoaderDiag {
+        enum ErrorType {
+            NONE,
+            CANNOT_BE_LOCATED,
+            CANNOT_BE_LOADED
+        };
+
+        bool present;
+        ErrorType errType = NONE;
+    };
+    /* Checks if the Vulkan loader exists on the current system.
+        @return The operation's result and metadata.
+    */
+    inline VkLoaderDiag VulkanLoaderExists() {
+#ifdef _WIN32
+        HMODULE handle = LoadLibraryA(VULKAN_LOADER);
+        if (!handle)
+            return { false, VkLoaderDiag::CANNOT_BE_LOCATED };
+
+        auto procAddr = (void *)GetProcAddress(handle, "vkGetInstanceProcAddr");
+        FreeLibrary(handle);
+
+        if (!procAddr)
+            return { false,VkLoaderDiag::CANNOT_BE_LOADED };
+
+        return { true };
+
+
+#elif defined(__linux__) || defined(__APPLE)
+        void *handle = dlopen(VULKAN_LOADER, RTLD_NOW | RTLD_LOCAL);
+        if (!handle) {
+#ifdef __linux__
+            handle = dlopen(VULKAN_LOADER_LINUX_FALLBACK, RTLD_NOW | RTLD_LOCAL);
+#elif __APPLE__
+            handle = dlopen(VULKAN_LOADER_APPLE_FALLBACK, RTLD_NOW | RTLD_LOCAL);
+#endif
+            if (!handle)
+                return { false, VkLoaderDiag::CANNOT_BE_LOCATED };
+        }
+
+        auto procAddr = dlsym(handle, "vkGetInstanceProcAddr");
+        dlclose(handle);
+
+        if (!procAddr)
+            return { false,VkLoaderDiag::CANNOT_BE_LOADED };
+
+        return { true };
+#endif
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This pull request adds platform-specific Vulkan loader presence checks and integrates that validation into application startup. It also refactors engine startup to separate main-window loading from initialization.

## Changes

### Core Utilities
- src/Core/Utils/SystemUtils.hpp (+63/-0)
  - Added SystemUtils::VkLoaderDiag struct with:
    - bool present
    - enum ErrorType { NONE, UNSUPPORTED, CANNOT_BE_LOCATED, CANNOT_BE_LOADED }
  - Added inline SystemUtils::VulkanLoaderExists() which:
    - Attempts to dynamically load the Vulkan loader and resolve vkGetInstanceProcAddr.
    - Uses platform APIs:
      - Windows: LoadLibraryA(VULKAN_LOADER) + GetProcAddress("vkGetInstanceProcAddr")
      - Linux/macOS: dlopen(VULKAN_LOADER) with a fallback dlopen of platform-specific fallback name, then dlsym("vkGetInstanceProcAddr")
    - Returns present=true only if the symbol is found; sets errType appropriately on failure; returns UNSUPPORTED on other platforms.

### Platform Constants
- src/Core/Data/Constants.h (+11/-1)
  - Added OS-specific macros for loader names:
    - Windows: VULKAN_LOADER = "vulkan-1.dll"
    - Linux: VULKAN_LOADER = "libvulkan.so.1", VULKAN_LOADER_LINUX_FALLBACK = "libvulkan.so"
    - macOS: VULKAN_LOADER = "libvulkan.1.dylib", VULKAN_LOADER_APPLE_FALLBACK = "libvulkan.dylib"

### Application Integration
- src/Application/Application.cpp (+36/-1)
  - Added checkVulkanLoader() helper that:
    - Calls SystemUtils::VulkanLoaderExists()
    - Builds OS-appropriate error messages for CANNOT_BE_LOCATED and generic messages for CANNOT_BE_LOADED / UNSUPPORTED
    - Enforces existence via LOG_ASSERT(vkLoaderDiag.present, vkLoaderErrMsg)
  - Updated main():
    - Instantiates Engine earlier (Engine engine;)
    - Calls Log::BeginLogging() / Log::PrintAppInfo(), then checkVulkanLoader() before engine.init()
    - After init, retains the 3s splash delay and explicitly calls engine.loadMainWindow() before engine.run()

### Engine refactor
- src/Application/Engine.cpp (+12/-14)
  - Engine constructor now only sets up core services, events, and creates the splash window; it no longer calls init() or performs the splash→primary transition.
  - Added Engine::loadMainWindow() to perform:
    - Transition from splash to primary window, setMainWindow(), and dispatch UpdateEvent::AppIsStable and UpdateEvent::ApplicationStatus{IDLE}
  - setMainWindow() continues to recreate swapchain and dispatch RequestEvent::ReInitImGui.

- src/Application/Engine.hpp (+2/-0)
  - Declared new public method: void loadMainWindow();

## Rationale
- Provide an early, platform-specific validation of the Vulkan loader to fail fast with actionable messages when the runtime is missing or damaged.
- Separate window-loading flow from Engine initialization to allow loader validation (and other pre-init checks) to occur before attempting full engine startup and resource initialization.

## Impact
- Adds runtime dependency checks across Windows, Linux, and macOS with fallbacks for common library names.
- Alters startup ordering: Engine is constructed earlier, initialization and main-window loading are distinct steps; callers (main) now explicitly call init(), sleep, loadMainWindow(), then run().
<!-- end of auto-generated comment: release notes by coderabbit.ai -->