### PR TITLE
fix: abstract buffer byte-size calculation for STL containers

### DIFF
--- a/src/Core/Utils/SystemUtils.hpp
+++ b/src/Core/Utils/SystemUtils.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <random>
 #include <chrono>
+#include <limits>
 #include <cstdlib>
 #include <concepts>
 #include <functional>
@@ -63,7 +64,14 @@ namespace SystemUtils {
 
     template<HasSizeMethod Container>
     size_t ByteSize(const Container &c) {
-        return static_cast<size_t>(sizeof(typename Container::value_type) * c.size());
+        constexpr size_t elemSz = sizeof(typename Container::value_type);
+        const size_t cnt = static_cast<size_t>(c.size());
+        LOG_ASSERT(
+            cnt <= (std::numeric_limits<size_t>::max)() / elemSz,
+            "ByteSize overflow: container size exceeds addressable byte range."
+        );
+
+        return elemSz * cnt;
     }
 
 

--- a/src/Core/Utils/SystemUtils.hpp
+++ b/src/Core/Utils/SystemUtils.hpp
@@ -53,6 +53,20 @@ namespace SystemUtils {
     };
 
 
+    // Concept: Has `size` method
+    template<typename T>
+    concept HasSizeMethod = requires(const T & container) {
+        { container.size() } -> std::convertible_to<std::size_t>;
+        typename T::value_type;
+    };
+
+
+    template<HasSizeMethod Container>
+    size_t ByteSize(const Container &c) {
+        return static_cast<size_t>(sizeof(typename Container::value_type) * c.size());
+    }
+
+
     /* Combines multiple hash values into a single hash value. 
 		This function uses the std::hash function to generate a hash for the value and combines it with the seed using a bitwise XOR operation and some arithmetic operations.
 		

--- a/src/Engine/Systems/RenderSystem.cpp
+++ b/src/Engine/Systems/RenderSystem.cpp
@@ -100,9 +100,9 @@ void RenderSystem::initOrbitVertexArray() {
 void RenderSystem::initGlobalBuffers() {
 	// Global vertex & index buffers
 	{
-		VkDeviceSize vertBufSize	= sizeof(m_geomData->meshVertices[0]) * m_geomData->meshVertices.size();
-		VkDeviceSize idxBufSize		= sizeof(m_geomData->meshVertexIndices[0]) * m_geomData->meshVertexIndices.size();
-		VkBufferUsageFlags commonBufUsage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+		VkDeviceSize vertBufSize			= SystemUtils::ByteSize(m_geomData->meshVertices);
+		VkDeviceSize idxBufSize				= SystemUtils::ByteSize(m_geomData->meshVertexIndices);
+		VkBufferUsageFlags commonBufUsage	= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
 		m_globalVertBufAlloc	= m_bufferManager->allocate(vertBufSize, commonBufUsage | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, Buffer::MemIntent::VRAM);
 		m_globalIdxBufAlloc		= m_bufferManager->allocate(idxBufSize, commonBufUsage | VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Buffer::MemIntent::VRAM);
@@ -115,7 +115,7 @@ void RenderSystem::initGlobalBuffers() {
 
 	// Orbit trajectory vertex buffer
 	if (!m_orbitWorldVertices.empty()) {
-		VkDeviceSize bufSize = sizeof(glm::dvec3) * m_orbitWorldVertices.size();
+		VkDeviceSize bufSize = SystemUtils::ByteSize(m_orbitWorldVertices);
 
 		m_orbitVertBufAlloc = m_bufferManager->allocate(
 			bufSize,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR abstracts buffer byte-size calculation for STL containers into a reusable utility function, improving code maintainability and reducing repeated size calculation logic.

## Changes

### Core/Utils/SystemUtils.hpp
Added two new utility components for calculating container byte sizes:

- **Concept `HasSizeMethod`**: Constrains template types to those with a `size()` method and a `value_type` member, ensuring type safety for container operations.
- **Function `ByteSize`**: Template function that computes the total byte size of a container by multiplying `sizeof(value_type) * container.size()`. Returns a `size_t` value representing the byte count.

### Engine/Systems/RenderSystem.cpp
Modified `initGlobalBuffers()` to use the new `SystemUtils::ByteSize()` utility for buffer allocation size calculations:

- Global mesh vertex buffer size calculation now uses `SystemUtils::ByteSize(m_geomData->meshVertices)`
- Global mesh index buffer size calculation now uses `SystemUtils::ByteSize(m_geomData->meshVertexIndices)`
- Orbit trajectory vertex buffer size calculation now uses `SystemUtils::ByteSize(m_orbitWorldVertices)`

These changes replace inline size calculations while maintaining the same buffer allocation and data upload logic.

## Impact
- **Abstraction**: Centralizes buffer byte-size calculation logic, reducing code duplication
- **Safety**: C++20 concepts provide compile-time type checking for containers
- **Maintainability**: Single point of modification if calculation logic needs to change in the future

<!-- end of auto-generated comment: release notes by coderabbit.ai -->