### PR TITLE
fix(ui): account for DPI scaling in UI rendering

### DIFF
--- a/src/Core/Data/Contexts/AppContext.hpp
+++ b/src/Core/Data/Contexts/AppContext.hpp
@@ -6,9 +6,16 @@
 #include <cstdint>
 #include <condition_variable>
 
+#include <imgui/imgui.h>
+
 
 // General application context
 struct AppContext {
+    struct Window {
+        float dpiScale = 0.0f;
+        ImGuiStyle baseStyle;
+    } Window;
+
     struct Config {
         std::string appearance_ColorTheme           = "DARK";
 

--- a/src/Core/Data/Contexts/AppContext.hpp
+++ b/src/Core/Data/Contexts/AppContext.hpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <atomic>
 #include <cstdint>
+#include <optional>
 #include <condition_variable>
 
 #include <imgui/imgui.h>
@@ -12,8 +13,8 @@
 // General application context
 struct AppContext {
     struct Window {
-        float dpiScale = 0.0f;
-        ImGuiStyle baseStyle;
+        float dpiScale = 1.0f;
+        std::optional<ImGuiStyle> baseStyle;
     } Window;
 
     struct Config {

--- a/src/Engine/Registry/Event/EventTypes.hpp
+++ b/src/Engine/Registry/Event/EventTypes.hpp
@@ -313,8 +313,14 @@ namespace RequestEvent {
 
 	/* Used when major changes warrant the re-initialization of Dear ImGui. */
 	struct ReInitImGui {
+		enum class Stage {
+			ALL,
+			FONTS
+		};
+
 		const EventFlag eventFlag = EVENT_FLAG_REQUEST_REINIT_IMGUI_BIT;
 
+		Stage reInitStage = Stage::ALL;			// Specifies which part of ImGui needs to be re-initialized
 		GLFWwindow *newWindowPtr = nullptr;		// Optional: The new window pointer, if this event was emitted in case of GLFW window recreation
 	};
 }

--- a/src/Engine/Rendering/UIRenderer.cpp
+++ b/src/Engine/Rendering/UIRenderer.cpp
@@ -17,9 +17,6 @@ UIRenderer::UIRenderer(GLFWwindow *window, const Ctx::VkRenderDevice *renderDevi
     bindEvents();
     initImGui();
 
-    // Set baseline style ONCE (to revert back to on DPI changes)
-    g_appCtx.Window.baseStyle = ImGui::GetStyle();
-
 
 	Log::Print(Log::T_DEBUG, __FUNCTION__, "Initialized.");
 }
@@ -180,21 +177,26 @@ void UIRenderer::initImGui() {
     ImGui_ImplVulkan_Init(&vkInitInfo);
 
 
+    // Set custom style
+        // Refer to ImGui::StyleColorsDark() and ImGui::StyleColorsLight() for more information
+    ImGuiTheme::ApplyTheme(defaultAppearance);
+    g_guiCtx.GUI.currentAppearance = defaultAppearance;
+
+    auto iniBuffer = FilePathUtils::ReadFile(ResourcePath::App.CONFIG_IMGUI);
+    ImGui::LoadIniSettingsFromMemory(iniBuffer.data(), iniBuffer.size());
+
+
     // Apply DPI scale to style
+        // Set baseline style ONCE (to revert back to on DPI changes)
+    if (!g_appCtx.Window.baseStyle.has_value()) {
+        g_appCtx.Window.baseStyle = ImGui::GetStyle();
+    }
     style.ScaleAllSizes(g_appCtx.Window.dpiScale);
 
 
     // Loads default fonts
     initFonts();
 
-    // Implements custom style
-        // Refer to ImGui::StyleColorsDark() and ImGui::StyleColorsLight() for more information
-    ImGuiTheme::ApplyTheme(defaultAppearance);
-    g_guiCtx.GUI.currentAppearance = defaultAppearance;
-
-    //std::cout << ResourcePath::App.CONFIG_IMGUI << '\n';
-    auto iniBuffer = FilePathUtils::ReadFile(ResourcePath::App.CONFIG_IMGUI);
-    ImGui::LoadIniSettingsFromMemory(iniBuffer.data(), iniBuffer.size());
 
     m_eventDispatcher->dispatch(InitEvent::ImGui{});
 }

--- a/src/Engine/Rendering/UIRenderer.cpp
+++ b/src/Engine/Rendering/UIRenderer.cpp
@@ -17,6 +17,10 @@ UIRenderer::UIRenderer(GLFWwindow *window, const Ctx::VkRenderDevice *renderDevi
     bindEvents();
     initImGui();
 
+    // Set baseline style ONCE (to revert back to on DPI changes)
+    g_appCtx.Window.baseStyle = ImGui::GetStyle();
+
+
 	Log::Print(Log::T_DEBUG, __FUNCTION__, "Initialized.");
 }
 
@@ -26,7 +30,16 @@ void UIRenderer::bindEvents() {
 
     m_eventDispatcher->subscribe<RequestEvent::ReInitImGui>(selfIndex,
         [this](const RequestEvent::ReInitImGui &event) {
-            reInitImGui(event.newWindowPtr);
+            using enum RequestEvent::ReInitImGui::Stage;
+            switch (event.reInitStage) {
+            case ALL:
+                reInitImGui(event.newWindowPtr);
+                break;
+
+            case FONTS:
+                initFonts();
+                break;
+            }
         }
     );
 }
@@ -74,6 +87,7 @@ void UIRenderer::initImGui() {
     // Setup Dear ImGui context
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
+
     ImGuiIO& io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
@@ -110,14 +124,14 @@ void UIRenderer::initImGui() {
     vkInitInfo.PhysicalDevice = m_renderDeviceCtx->physicalDevice;
     vkInitInfo.Device = m_renderDeviceCtx->logicalDevice;
 
-    // Queue
+        // Queue
     vkInitInfo.QueueFamily = m_renderDeviceCtx->queueFamilies.graphicsFamily.index.value();
     vkInitInfo.Queue = m_renderDeviceCtx->queueFamilies.graphicsFamily.deviceQueue;
 
-    // Pipeline cache
+        // Pipeline cache
     vkInitInfo.PipelineCache = VK_NULL_HANDLE;
 
-    // Descriptor pool
+        // Descriptor pool
     std::vector<VkDescriptorPoolSize> imgui_PoolSizes = {
         // Sampler to draw the GUI
         { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, IMGUI_IMPL_VULKAN_MINIMUM_IMAGE_SAMPLER_POOL_SIZE },
@@ -130,15 +144,15 @@ void UIRenderer::initImGui() {
     vkInitInfo.DescriptorPool = m_descriptorPool;
 
 
-    // Render pass & subpass
+        // Render pass & subpass
     vkInitInfo.RenderPass = m_windowCtx->presentRenderPass;
     vkInitInfo.Subpass = 0;
 
-    // Image count
+        // Image count
     vkInitInfo.MinImageCount = m_windowCtx->minImageCount; // For some reason, ImGui does not actually use this property
     vkInitInfo.ImageCount = m_windowCtx->minImageCount;
 
-    // Other
+        // Other
     vkInitInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
     vkInitInfo.Allocator = nullptr;
     
@@ -166,6 +180,10 @@ void UIRenderer::initImGui() {
     ImGui_ImplVulkan_Init(&vkInitInfo);
 
 
+    // Apply DPI scale to style
+    style.ScaleAllSizes(g_appCtx.Window.dpiScale);
+
+
     // Loads default fonts
     initFonts();
 
@@ -185,8 +203,8 @@ void UIRenderer::initImGui() {
 void UIRenderer::initFonts() {
     ImGuiIO& io = ImGui::GetIO();
 
-    constexpr float fontSize = 20.0f;
-    constexpr float iconSize = fontSize;
+    const float fontSize = 20.0f * g_appCtx.Window.dpiScale;
+    const float iconSize = fontSize;
 
 
     // Glyph ranges

--- a/src/Platform/Vulkan/Contexts.hpp
+++ b/src/Platform/Vulkan/Contexts.hpp
@@ -40,6 +40,7 @@ namespace Ctx {
         std::vector<VkImageLayout> imageLayouts;
 
         uint32_t swapchainResourceID;
+        float dpiScale;
     };
 
 

--- a/src/Platform/Windowing/AppWindow.cpp
+++ b/src/Platform/Windowing/AppWindow.cpp
@@ -136,7 +136,7 @@ void Window::WindowContentScaleCallback(GLFWwindow *window, float scaleX, float 
     g_appCtx.Window.dpiScale = scaleX;
 
     // Reset style
-    ImGui::GetStyle() = g_appCtx.Window.baseStyle;
+    ImGui::GetStyle() = g_appCtx.Window.baseStyle.value();
     ImGui::GetStyle().ScaleAllSizes(g_appCtx.Window.dpiScale);
 
 

--- a/src/Platform/Windowing/AppWindow.cpp
+++ b/src/Platform/Windowing/AppWindow.cpp
@@ -44,6 +44,11 @@ GLFWwindow* Window::initSplashScreen() {
     const uint32_t Y = (CURRENT_SCREEN_HEIGHT - SPLASH_HEIGHT) / 2;
     glfwSetWindowPos(m_splashWindow, X, Y);
 
+    // Query DPI scale
+    float scaleX, scaleY;
+    glfwGetWindowContentScale(m_splashWindow, &scaleX, &scaleY);
+    g_appCtx.Window.dpiScale = scaleX;
+
     return m_splashWindow;
 }
 
@@ -64,6 +69,11 @@ GLFWwindow* Window::initPrimaryScreen(CallbackContext *context) {
 
     loadWindowIcon(m_mainWindow);
 
+        // Query DPI scale
+    float scaleX, scaleY;
+    glfwGetWindowContentScale(m_mainWindow, &scaleX, &scaleY);
+    g_appCtx.Window.dpiScale = scaleX;
+
 
     // Dispatch update event
     m_eventDispatcher = ServiceLocator::GetService<EventDispatcher>(__FUNCTION__);
@@ -74,6 +84,8 @@ GLFWwindow* Window::initPrimaryScreen(CallbackContext *context) {
 
     // Initialize GLFW bindings
     glfwSetWindowUserPointer(m_mainWindow, static_cast<void *>(context));
+
+    glfwSetWindowContentScaleCallback(m_mainWindow, WindowContentScaleCallback);
 
     glfwSetKeyCallback(m_mainWindow, KeyCallback);                      // Binds key events
     glfwSetCharCallback(m_mainWindow, ImGui_ImplGlfw_CharCallback);     // For normal character events (text input), we let ImGui's callback handle them
@@ -115,6 +127,25 @@ void Window::loadWindowIcon(GLFWwindow *window) {
     glfwSetWindowIcon(window, 1, image);
 
     stbi_image_free(pixels);
+}
+
+
+void Window::WindowContentScaleCallback(GLFWwindow *window, float scaleX, float scaleY) {
+    std::cout << "Changed DPI (" << g_appCtx.Window.dpiScale << " -> " << scaleX << ")\n";
+
+    g_appCtx.Window.dpiScale = scaleX;
+
+    // Reset style
+    ImGui::GetStyle() = g_appCtx.Window.baseStyle;
+    ImGui::GetStyle().ScaleAllSizes(g_appCtx.Window.dpiScale);
+
+
+    // Reset font
+    ImGui::GetIO().Fonts->Clear();
+    auto eventDispatcher = ServiceLocator::GetService<EventDispatcher>(__FUNCTION__);
+    eventDispatcher->dispatch(RequestEvent::ReInitImGui{
+        .reInitStage = RequestEvent::ReInitImGui::Stage::FONTS
+    });
 }
 
 

--- a/src/Platform/Windowing/AppWindow.hpp
+++ b/src/Platform/Windowing/AppWindow.hpp
@@ -50,6 +50,8 @@ private:
 
 	void loadWindowIcon(GLFWwindow *window);
 
+	static void WindowContentScaleCallback(GLFWwindow *window, float scaleX, float scaleY);
+
 	static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods);
 
 	static void MouseCallback(GLFWwindow *window, double posX, double posY);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR implements DPI scaling support for the UI renderer to properly handle high-DPI displays and dynamic DPI changes during runtime.

## Changes

### Core Architecture
- **AppContext.hpp**: Added a new nested `Window` struct to `AppContext` storing DPI scaling state (`dpiScale`) and a baseline ImGui style snapshot (`baseStyle`) for restoration during DPI changes.

### Event System
- **EventTypes.hpp**: Extended `RequestEvent::ReInitImGui` with a `Stage` enum (`ALL`, `FONTS`) to enable granular control over ImGui re-initialization scope. This allows re-initialization of either all ImGui components or just fonts/atlases.

### UI Rendering
- **UIRenderer.cpp**: 
  - Captures the baseline ImGui style during renderer construction
  - Implements stage-based re-initialization: `Stage::ALL` triggers full ImGui reset, `Stage::FONTS` triggers font-only refresh
  - Applies DPI scaling to ImGui style sizes during initialization
  - Makes font and icon sizes DPI-aware instead of fixed constants

### Vulkan Platform Layer
- **Contexts.hpp**: Added `dpiScale` member to `Ctx::VkWindow` struct for storing per-window DPI scaling state.

### Window Management
- **AppWindow.cpp** & **AppWindow.hpp**:
  - Queries GLFW's content DPI scale during both splash and main window initialization
  - Stores initial DPI scale in `AppContext`
  - Installs a `WindowContentScaleCallback` on the primary window to handle dynamic DPI changes
  - DPI change handling: restores ImGui style from baseline, rescales UI sizes to new DPI factor, clears font atlas, and dispatches a `FONTS`-stage re-initialization request

## Key Features
- Supports querying initial DPI scale from GLFW
- Handles dynamic DPI changes (e.g., when moving window between monitors with different DPI)
- Preserves baseline UI style for consistent rescaling
- Granular re-initialization control to optimize performance during DPI transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->