### PR TITLE
fix: explicitly join thread on destruction to resolve use-after-free …

### DIFF
--- a/src/Core/Application/Threading/WorkerThread.hpp
+++ b/src/Core/Application/Threading/WorkerThread.hpp
@@ -24,8 +24,14 @@ public:
 		});
 	}
 	
-	~WorkerThread() = default; // NOTE: std::jthread automatically joins the thread on destruction (instead of std::thread, which calls std::terminate if the thread has not been joined)
+	~WorkerThread() {
+		// NOTE: std::jthread automatically joins the thread on destruction (instead of std::thread, which calls std::terminate if the thread has not been joined)
+		// However, we should still explicitly join it on destruction (making jthread::~jthread auto-joining a no-op) so that it is destroyed before other memory it might try to access on joining like condition variables
 
+		m_thread.request_stop();
+		if (m_thread.joinable())
+			m_thread.join();
+	}
 
 	/* Defines the worker thread with the given callable function/lambda.
 		@tparam Callable: The callable type (e.g., function pointer, lambda, functor). The callable must accept a std::stop_token.
@@ -100,7 +106,6 @@ public:
     inline std::thread::id getID() const { return m_thread.get_id(); }
 
 private:
-	std::jthread m_thread;
 	std::mutex m_mutex;
 	std::condition_variable_any m_cv; // Use std::condition_variable_any as it is required to work with std::stop_token
 
@@ -114,6 +119,10 @@ private:
 	std::atomic<bool> m_stopRequested{ false };
 	std::atomic<bool> m_detached{ false };
 	
+	// Declare jthread last: in C++, construction and destruction follow a LIFO approach.
+	// This means we must destroy jthread first (declare last), as it auto-joins on destruction and thus might try to access memory (e.g., condition variables)
+	// that would have already been destroyed if jthread was destroyed last (declared first).
+	std::jthread m_thread;
 
 	void threadLoop(std::stop_token stopToken) {
 		// stopToken.stop_requested() will only be true if the associated thread has been destroyed.


### PR DESCRIPTION
…errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR fixes use-after-free errors in the `WorkerThread` destructor by explicitly managing thread shutdown and ensuring proper member destruction order.

## Changes

**File modified:** `src/Core/Application/Threading/WorkerThread.hpp`

### Destructor Implementation
The destructor was changed from a defaulted implementation to a custom one that:
- Calls `m_thread.request_stop()` to signal the thread to stop
- Conditionally calls `m_thread.join()` if the thread is joinable, ensuring the thread completes before further destruction

### Member Declaration Order
The `m_thread` member was moved to the end of the private member declarations (LIFO - Last In, First Out destruction order). This ensures that when the destructor runs and the thread joins, it doesn't attempt to access other members (such as `m_cv` condition variable) that have already been destroyed.

## Rationale

While `std::jthread` automatically joins on destruction (unlike `std::thread`), explicit joining is necessary to guarantee that the thread completes before other member variables are destroyed. This prevents the thread from attempting to access freed memory (condition variables, mutexes, etc.) during its final cleanup phase.

## Impact

- Resolves potential use-after-free errors during `WorkerThread` object destruction
- Ensures thread-safe cleanup of worker threads with proper synchronization primitive lifecycle management
- No changes to public API or behavior; purely a safety fix for object destruction semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->