### PR TITLE
docs: specify exclamation mark usage in branch- and commit-naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,12 @@ Examples:
 - `chore(build): add Catch2 as test dependency`
 - `docs: update installation prerequisites`
 
+
+When breaking changes are made to existing APIs, place an exclamation mark (`!`) after the branch type or scope.
+Examples:
+- `feat!: remove vestigial parameters from Log::Print`
+- `feat(physics)!: remove deprecated API`
+
 ---
 
 ## Pull Requests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Breaking API Change Convention

Added documentation specifying the use of exclamation marks in branch and commit naming conventions when introducing breaking API changes. The new guidance clarifies that an exclamation mark (`!`) must be placed after the branch type or scope in both branch names and commit messages.

Two examples provided:
- `feat!: remove vestigial parameters from Log::Print`
- `feat(physics)!: remove deprecated API`

This addition to the Commits section of CONTRIBUTING.md establishes a clear standard for communicating breaking changes in the project's version control workflow, aligning with Conventional Commits semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ButteredFire/Astrocelerate/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->