### PR TITLE
feat: add curly-braces-style formatting support and worker-thread-logging for Log::Print

### DIFF
--- a/src/Core/Application/IO/LoggingManager.cpp
+++ b/src/Core/Application/IO/LoggingManager.cpp
@@ -5,7 +5,7 @@
 
 void Log::LogThreadInfo(std::string &output) {
 	std::thread::id currentThread = std::this_thread::get_id();
-	std::stringstream ss;
+	std::stringstream ss{};
 	ss << "THREAD " << currentThread << ", ";
 	if (currentThread == ThreadManager::GetMainThreadID())
 		ss << "MAIN";

--- a/src/Core/Application/IO/LoggingManager.cpp
+++ b/src/Core/Application/IO/LoggingManager.cpp
@@ -3,66 +3,16 @@
 #include <Core/Application/Threading/ThreadManager.hpp>
 
 
-namespace LogSpacing {
-	const int THREAD_INFO_MAX_WIDTH_OS = 30;
-	const int DISPLAY_TYPE_WIDTH = 9;
-	const int CALLER_WIDTH = 50;
-}
-
-
 void Log::LogThreadInfo(std::string &output) {
 	std::thread::id currentThread = std::this_thread::get_id();
 	std::stringstream ss;
-	ss << "[THREAD " << currentThread << ", ";
+	ss << "THREAD " << currentThread << ", ";
 	if (currentThread == ThreadManager::GetMainThreadID())
-		ss << "MAIN]";
+		ss << "MAIN";
 	else
-		ss << "WORKER]";
-		//ss << ThreadManager::GetThreadNameFromID(currentThread) << "]";
+		ss << ThreadManager::GetThreadNameFromID(currentThread);
 
 	output = ss.str();
-}
-
-
-void Log::Print(MsgType type, const char *caller, const std::string &message, bool newline) {
-	std::lock_guard<std::mutex> lock(m_printMutex);
-
-	// Get message type
-	std::string displayType = "Unknown message type";
-	LogColor(type, displayType);
-
-	// Get thread info
-	std::string threadInfo = "";
-	LogThreadInfo(threadInfo);
-
-	// Log
-	std::stringstream ss;
-	ss << std::left << std::setw(LogSpacing::THREAD_INFO_MAX_WIDTH_OS) << threadInfo
-		<< std::left << std::setw(LogSpacing::DISPLAY_TYPE_WIDTH) << ("[" + displayType + "]")
-		<< "[ " << std::left << std::setw(LogSpacing::CALLER_WIDTH) << caller << "]: "
-		<< message << ((newline) ? "\n" : "");
-
-	if (type == MsgType::T_ERROR || type == MsgType::T_FATAL)
-		std::cerr << ss.str() << termcolor::reset;
-	else
-		std::cout << ss.str() << termcolor::reset;
-
-		// Write to file
-	if (m_logFile.is_open()) {
-		m_logFile << ss.str();
-		m_logFile.flush();
-	}
-
-
-	// Push to log buffer
-	LogMessage msg{};
-	msg.type = type;
-	msg.displayType = displayType;
-	msg.threadInfo = threadInfo;
-	msg.caller = caller;
-	msg.message = ss.str();
-
-	AddToLogBuffer(msg);
 }
 
 

--- a/src/Core/Application/IO/LoggingManager.hpp
+++ b/src/Core/Application/IO/LoggingManager.hpp
@@ -169,18 +169,17 @@ public:
 	static void Print(MsgType type, const char *caller, const std::string_view messageFmt, Args&&... args) {
 		std::lock_guard<std::mutex> lock(m_printMutex);
 
-		// Get message type
 		std::string displayType = "Unknown message type";
 		LogColor(type, displayType);
 
-		// Get thread info
-		std::string threadInfo = "";
+		std::string threadInfo{};
 		LogThreadInfo(threadInfo);
 
-		// Log
+
+		// Log to console
 		std::string fmt = std::vformat(messageFmt, std::make_format_args(args...));
 		std::string logMsg = std::format(
-			"[{:^{}}][{:^{}}][{:^{}}]: {}",
+			"[{:^{}}][{:^{}}][{:^{}}]: {}\n",
 			threadInfo,		SPACING_THREAD_INFO_MAX_WIDTH_OS,
 			displayType,	SPACING_DISPLAY_TYPE_WIDTH,
 			caller,			SPACING_CALLER_WIDTH,
@@ -191,6 +190,7 @@ public:
 			std::cerr << logMsg << termcolor::reset;
 		else
 			std::cout << logMsg << termcolor::reset;
+
 
 		// Write to file
 		if (m_logFile.is_open()) {
@@ -316,12 +316,11 @@ public:
 
 
 private:
-	inline static std::mutex m_printMutex;
-	inline static std::ofstream m_logFile;
-	inline static std::string m_logFilePath;
-
-
 	inline static constexpr int SPACING_THREAD_INFO_MAX_WIDTH_OS = 20;
 	inline static constexpr int SPACING_DISPLAY_TYPE_WIDTH = 10;
 	inline static constexpr int SPACING_CALLER_WIDTH = 50;
+
+	inline static std::mutex m_printMutex;
+	inline static std::ofstream m_logFile;
+	inline static std::string m_logFilePath;
 };

--- a/src/Core/Application/IO/LoggingManager.hpp
+++ b/src/Core/Application/IO/LoggingManager.hpp
@@ -6,6 +6,8 @@
 #include <thread>
 #include <string>
 #include <chrono>
+#include <format>
+#include <utility>
 #include <iomanip>
 #include <fstream>
 #include <iostream>
@@ -160,10 +162,53 @@ public:
 	/* Logs a message. 
 		@param type: The message type. Refer to Log::MsgType to see supported types.
 		@param caller: The name of the function from which this function is called. It should always be __FUNCTION__.
-		@param message: The message to be logged.
-		@param newline (default: true): A boolean determining whether the message ends with a newline character (true), or not (false).
+		@param messageFmt: The message to be logged, which can be formatted with curly braces (see std::format curly-braces-style string formatting).
+		@param args...: The message format arguments.
 	*/
-	static void Print(MsgType type, const char *caller, const std::string &message, bool newline = true);
+    template<typename... Args>
+	static void Print(MsgType type, const char *caller, const std::string_view messageFmt, Args&&... args) {
+		std::lock_guard<std::mutex> lock(m_printMutex);
+
+		// Get message type
+		std::string displayType = "Unknown message type";
+		LogColor(type, displayType);
+
+		// Get thread info
+		std::string threadInfo = "";
+		LogThreadInfo(threadInfo);
+
+		// Log
+		std::string fmt = std::vformat(messageFmt, std::make_format_args(args...));
+		std::string logMsg = std::format(
+			"[{:^{}}][{:^{}}][{:^{}}]: {}",
+			threadInfo,		SPACING_THREAD_INFO_MAX_WIDTH_OS,
+			displayType,	SPACING_DISPLAY_TYPE_WIDTH,
+			caller,			SPACING_CALLER_WIDTH,
+			fmt
+		);
+
+		if (type == MsgType::T_ERROR || type == MsgType::T_FATAL)
+			std::cerr << logMsg << termcolor::reset;
+		else
+			std::cout << logMsg << termcolor::reset;
+
+		// Write to file
+		if (m_logFile.is_open()) {
+			m_logFile << logMsg;
+			m_logFile.flush();
+		}
+
+
+		// Push to log buffer
+		LogMessage msg{};
+		msg.type = type;
+		msg.displayType = displayType;
+		msg.threadInfo = threadInfo;
+		msg.caller = caller;
+		msg.message = logMsg;
+
+		AddToLogBuffer(msg);
+	}
 
 
 	/* Logs application information to the console. */
@@ -274,4 +319,9 @@ private:
 	inline static std::mutex m_printMutex;
 	inline static std::ofstream m_logFile;
 	inline static std::string m_logFilePath;
+
+
+	inline static constexpr int SPACING_THREAD_INFO_MAX_WIDTH_OS = 20;
+	inline static constexpr int SPACING_DISPLAY_TYPE_WIDTH = 10;
+	inline static constexpr int SPACING_CALLER_WIDTH = 50;
 };

--- a/src/Platform/Vulkan/VkDeviceManager.cpp
+++ b/src/Platform/Vulkan/VkDeviceManager.cpp
@@ -45,7 +45,12 @@ void VkDeviceManager::createPhysicalDevice(VkPhysicalDevice &physDevice, Physica
     bool isDeviceCompatible = bestDevice.isCompatible;
     uint32_t physicalDeviceScore = bestDevice.optionalScore;
 
-    Log::Print(Log::T_INFO, __FUNCTION__, ("Out of " + std::to_string(physDeviceCount) + " GPU(s), GPU " + enquote(bestDevice.name) + " was selected with the highest grading score of " + std::to_string(physicalDeviceScore) + "."));
+    Log::Print(Log::T_INFO, __FUNCTION__,
+        "Selected {} out of {} GPU(s); grading score is {}",
+        enquote(bestDevice.name),
+        physDeviceCount,
+        physicalDeviceScore
+    );
 
     if (physicalDevice == nullptr || !isDeviceCompatible) {
         throw Log::RuntimeException(__FUNCTION__, __LINE__, "No GPU on this machine supports the required features to run Astrocelerate!\nPlease ensure your GPUs have their drivers updated to support Vulkan " VULKAN_VERSION_STR ".");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR refactors the logging system to add curly-braces-style formatting support (std::format) and improve thread identification for worker threads. The Print implementation was moved into the header as a variadic template and the old string-based overload/implementation in the .cpp was removed.

## Key Changes

### Logging API & Implementation (LoggingManager.hpp)
- Replaced the concrete string-based Print overload with a variadic template:
  - Before: static void Print(MsgType type, const char *caller, const std::string &message, bool newline = true)
  - After:  template<typename... Args> static void Print(MsgType type, const char *caller, std::string_view messageFmt, Args&&... args)
- New Print implementation:
  - Thread-safe via m_printMutex.
  - Formats messages using std::vformat with curly-brace format strings and forwards args.
  - Builds a structured log line using std::format with bracketed fields and inline spacing-width constants for alignment.
  - Uses LogColor to set output color, routes T_ERROR/T_FATAL to std::cerr and other severities to std::cout.
  - Writes to the open log file (if any) and flushes.
  - Enqueues a LogMessage into the in-memory LogBuffer.
- Added includes (<format>, <utility>) and inline constexpr spacing constants used for aligned output.
- Log::Print is now defined inline in the header (template), removing the previous non-template implementation from the .cpp.

### Thread Identification (LoggingManager.cpp / Log::LogThreadInfo)
- Log::LogThreadInfo now produces an unbracketed, descriptive thread string:
  - Main thread: "THREAD <id>, MAIN"
  - Worker threads: "THREAD <id>, <thread-name>" (resolved via ThreadManager::GetThreadNameFromID)
- The old Print implementation and LogSpacing constants were removed from the .cpp (implementation consolidated into the header).

### Call-site updates
- Callers updated to use the new format-style API. Example (updated in VkDeviceManager::createPhysicalDevice):
  - Log::Print(Log::T_INFO, __FUNCTION__, "Selected {} out of {} GPU(s); grading score is {}", enquote(bestDevice.name), physDeviceCount, physicalDeviceScore);

## Other notes
- RuntimeException construction still records thread info and enqueues an exception-related LogMessage to the LogBuffer.
- Files affected (excerpted sizes): LoggingManager.hpp (325 lines), LoggingManager.cpp (81 lines), VkDeviceManager.cpp (379 lines).
- Estimated review effort: High — core logging API change (template/format-based) and call-site updates required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ButteredFire/Astrocelerate/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->